### PR TITLE
Fix up loading of binary STL assets from websocket responses

### DIFF
--- a/include/STLLoader.js
+++ b/include/STLLoader.js
@@ -5,6 +5,7 @@ import {
 	Float32BufferAttribute,
 	Loader,
 	LoaderUtils,
+	Mesh,
 	Vector3
 } from 'three';
 
@@ -108,7 +109,7 @@ class STLLoader extends Loader {
 
 		function isBinary( data ) {
 
-			const reader = new DataView( data );
+			const reader = new DataView( data.buffer, data.byteOffset );
 			const face_size = ( 32 / 8 * 3 ) + ( ( 32 / 8 * 3 ) * 3 ) + ( 16 / 8 );
 			const n_faces = reader.getUint32( 80, true );
 			const expect = 80 + ( 32 / 8 ) + ( n_faces * face_size );
@@ -161,7 +162,7 @@ class STLLoader extends Loader {
 
 		function parseBinary( data ) {
 
-			const reader = new DataView( data );
+			const reader = new DataView( data.buffer, data.byteOffset );
 			const faces = reader.getUint32( 80, true );
 
 			let r, g, b, hasColors = false, colors;
@@ -390,7 +391,7 @@ class STLLoader extends Loader {
 
 		const binData = ensureBinary( data );
 
-		return isBinary( binData ) ? parseBinary( binData ) : parseASCII( ensureString( data ) );
+		return new Mesh(isBinary( binData ) ? parseBinary( binData ) : parseASCII( ensureString( data ) ));
 
 	}
 

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -2231,7 +2231,7 @@ export class Scene {
       function (error: any) {
         if (that.findResourceCb) {
           // Get the mesh from the websocket server.
-          that.findResourceCb(uri, (mesh: any, error?: string) => {
+          that.findResourceCb(uri, (rawmesh: any, error?: string) => {
             if (error !== undefined) {
               // Mark the mesh as error in the loading manager.
               const manager = that.stlLoader.manager as WsLoadingManager;
@@ -2239,7 +2239,9 @@ export class Scene {
               return;
             }
 
-            onLoad(that.stlLoader.parse(new TextDecoder().decode(mesh)));
+            let decoded = that.stlLoader.parse(rawmesh);
+            decoded.name = uri;
+            onLoad(decoded);
 
             // Mark the mesh as done in the loading manager.
             const manager = that.stlLoader.manager as WsLoadingManager;

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -393,7 +393,7 @@ export class Transport {
 
       // Decode as UTF-8 to get the header.
       const str = new TextDecoder('utf-8').decode(fileReader.result as BufferSource);
-      const frameParts = str.split(',');
+      const frameParts = str.split(',', 4);
       const msgType = this.root.lookup(frameParts[2]) as Type;
       const buffer = new Uint8Array(fileReader.result as ArrayBuffer);
 


### PR DESCRIPTION
Was having errors loading STL files via the websocket message fallback. These changes correct the behaviour for my use case, but I am not sure the full range of uses cases here.