### PR TITLE
Relase 3-0-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gzweb",
-  "version": "2.0.14",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gzweb",
-      "version": "2.0.14",
+      "version": "3.0.0",
       "dependencies": {
         "eventemitter2": "^6.4.5",
         "fast-xml-parser": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gzweb",
-  "version": "2.0.14",
+  "version": "3.0.0",
   "description": "A library for Gazebo and data visualization.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Released version 3.0.0. Bumped major to 3 since I upgraded node and npm dependencies. GLTF support is now in place, and binary STL loading has been fixed.

I should start release notes....